### PR TITLE
Added support for pre-Android JointSpace TVs (model 2015) & added log capabilities

### DIFF
--- a/PhilipsTV.js
+++ b/PhilipsTV.js
@@ -11,9 +11,17 @@ class PhilipsTV {
         muted: false
     };
 
-    constructor(config) {
+    constructor(config, log) {
         const wolURL = config.wol_url;
-        const baseURL = `https://${config.ip_address}:1926/6/`;
+        var baseURL = `https://${config.ip_address}:1926/6/`;
+        this.model_year = config.model_year;
+        this.log = log;
+
+        if (this.model_year == 2015) {
+            baseURL = `http://${config.ip_address}:1925/6/`;
+        } else {
+            baseURL = `https://${config.ip_address}:1926/6/`;
+        }
 
         this.api = (path, body = null) => {
             return new Promise((success, fail) => {
@@ -139,10 +147,13 @@ class PhilipsTV {
     setSource = async (input, callback) => {
         if (input.channel) {
             await this.sendKey("WatchTV");
-//            await this.sendKey("Digit" + input.channel);
-//            await this.sendKey("Confirm");
-            const ccid = await this.presetToCCid(input.channel);
-            await this.setChannel(ccid);
+            if (this.model_year == 2015) {
+                await this.sendKey("Digit" + input.channel);
+                await this.sendKey("Confirm");
+            } else {
+                const ccid = await this.presetToCCid(input.channel);
+                await this.setChannel(ccid);
+            }
         } else if (input.launch) {
             await this.launchApp(input.launch);
         } else {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ class PhilipsTvAccessory {
     tvService = null;
 
     constructor(log, config) {
+        this.log = log;
         this.config = {...this.config, ...config};
-        this.PhilipsTV = new PhilipsTV(config);
+        this.PhilipsTV = new PhilipsTV(config, log);
 
         this.registerAccessoryInformationService();
         this.registerTelevisionService();
@@ -80,6 +81,8 @@ class PhilipsTvAccessory {
 
         this.tvService = tvService;
         this.services.push(tvService);
+
+        this.log(`Initialized TV: ${name}, ${this.config.model_year} model`);
     };
 
     registerInputService = () => {


### PR DESCRIPTION
Should work with both Android and non-Android but I don't have an Android TV to test, so please double check everything before merging.

What works: 
- Power (WoL/sleep/poll)
- Volume
- Channel select (through manual config)

Used "2015" as the model number for non-Androids, even though I think mine is a 2016 model.